### PR TITLE
Export download-only function from mod.ts

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -25,12 +25,8 @@ export interface PreprareOptions {
   };
 }
 
-export async function prepare(options: PreprareOptions) {
-  const { name, urls, printLog = true, checkCache = true } = options;
-
-  if (printLog) {
-    await log.setup({});
-  }
+export async function download(options: PreprareOptions): string {
+  const { name, urls, checkCache = true } = options;
 
   const remoteUrl = urls[os];
   const remoteHash = md5.digest(encode(remoteUrl + pluginSuffix)).hex();
@@ -53,6 +49,18 @@ export async function prepare(options: PreprareOptions) {
       await downloadFromRemote(name, remoteUrl, localPath);
     }
   }
+  
+  return localPath;
+}
+
+export async function prepare(options: PreprareOptions) {
+  const { name, printLog = true } = options;
+
+  if (printLog) {
+    await log.setup({});
+  }
+
+  const localPath = await download(options);
 
   log.info(`load deno plugin "${name}" from local "${localPath}"`);
   return Deno.openPlugin(localPath);

--- a/mod.ts
+++ b/mod.ts
@@ -25,7 +25,7 @@ export interface PreprareOptions {
   };
 }
 
-export async function download(options: PreprareOptions): string {
+export async function download(options: PreprareOptions) {
   const { name, urls, checkCache = true } = options;
 
   const remoteUrl = urls[os];


### PR DESCRIPTION
This can be used to fetch a plugin without actually loading it. I'm planning to use this as part of CI preparations, instead of the plugin downloading when the program first runs. `deno cache` doesn't perform the plugin download currently, of course.