### PR TITLE
Upgrade modules versions

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
-export { exists } from "https://deno.land/std@v0.51.0/fs/exists.ts";
-export * as log from "https://deno.land/std@v0.51.0/log/mod.ts";
-export * as path from "https://deno.land/std@v0.51.0/path/mod.ts";
+export { exists } from "https://deno.land/std@v0.61.0/fs/exists.ts";
+export * as log from "https://deno.land/std@v0.61.0/log/mod.ts";
+export * as path from "https://deno.land/std@v0.61.0/path/mod.ts";
 
 export { Hash } from "https://deno.land/x/checksum@1.4.0/mod.ts";


### PR DESCRIPTION
prepare_plugin is broken in `deno 1.2.0`.
this breaks some dependent modules
thanks for upgrading