### PR TITLE
fix std import link

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
-export { exists } from "https://deno.land/std@v0.61.0/fs/exists.ts";
-export * as log from "https://deno.land/std@v0.61.0/log/mod.ts";
-export * as path from "https://deno.land/std@v0.61.0/path/mod.ts";
+export { exists } from "https://deno.land/std@0.61.0/fs/exists.ts";
+export * as log from "https://deno.land/std@0.61.0/log/mod.ts";
+export * as path from "https://deno.land/std@0.61.0/path/mod.ts";
 
 export { Hash } from "https://deno.land/x/checksum@1.4.0/mod.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,8 +1,8 @@
 export {
   assert,
   assertEquals,
-} from "https://deno.land/std@v0.51.0/testing/asserts.ts";
+} from "https://deno.land/std@0.51.0/testing/asserts.ts";
 
-export { serve } from "https://deno.land/std@v0.51.0/http/server.ts";
-export { serveFile } from "https://deno.land/std@v0.51.0/http/file_server.ts";
-export { resolve } from "https://deno.land/std@v0.51.0/path/posix.ts";
+export { serve } from "https://deno.land/std@0.51.0/http/server.ts";
+export { serveFile } from "https://deno.land/std@0.51.0/http/file_server.ts";
+export { resolve } from "https://deno.land/std@0.51.0/path/posix.ts";


### PR DESCRIPTION
import of std deno library must be without the `v` for version. Not working anymore as it is now